### PR TITLE
Update Dockerfile to optimize size and cache images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM node:6.11
+FROM node:6-alpine
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install app dependencies
-COPY package.json /usr/src/app/
-RUN npm install
-
-# Bundle app source
 COPY . /usr/src/app
-RUN cp /usr/src/app/config.example.js /usr/src/app/config.js
 
+RUN rm -rf node_modules \
+  && npm install \
+  && cp /usr/src/app/config.example.js /usr/src/app/config.js
 
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -59,4 +59,6 @@
 
 Mattermost will type it into the channel.
 
+![capture](https://i.ibb.co/JdGwMcJ/Capture.png)
+
 Link to [Docker hub](https://hub.docker.com/r/kaylleur/mattermost-integration-deezer-spotify-link/)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5774198/51148365-36fc2f00-185e-11e9-8db6-3214bafeab54.png)

Gros gain de place avec l'utilisation de l'image de base [alpine](https://hub.docker.com/_/alpine), hyper light mais très maintenue. 670Mb -> 65Mb